### PR TITLE
Add actions to change input and control volume

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -14,3 +14,5 @@ This module supports;
 
 * Pairing the device
 * Power on/off
+* Changing the input
+* Adjusting volume and mute status

--- a/index.js
+++ b/index.js
@@ -81,6 +81,14 @@ instance.prototype.actions = function (system) {
 				default: 'power_on',
 				choices: [{ label: 'power on', id: 'power_on' }, { label: 'power off', id: 'power_off' }]
 			}]
+		},
+		'input': {
+			label: 'Active Input',
+			options: [{
+				type: 'textinput',
+				label: 'Enter name of the input to make active',
+				id: 'input'
+			}]
 		}
 	});
 };
@@ -120,6 +128,10 @@ instance.prototype.action = function (action) {
 				tv.control.power.on();
 			}
 
+			break;
+
+		case 'input':
+			tv.input.set(opt.input);
 			break;
 	}
 };

--- a/index.js
+++ b/index.js
@@ -17,12 +17,38 @@ instance.prototype.init = function () {
 	var self = this;
 
 	self.status(self.STATUS_UNKNOWN);
+	self.loadInputs();
 };
 
 instance.prototype.updateConfig = function (config) {
 	var self = this;
 	self.config = config;
+	self.loadInputs();
 };
+
+instance.prototype.loadInputs = function () {
+	var self = this;
+	self.INPUTS = [];
+
+	self.log('debug', 'Enumerating inputs.');
+	if (self.config.host && self.config.authToken) {
+		var tv = new smartcast(self.config.host, self.config.authToken);
+		tv.input.list().then(
+			function(result) {
+				for(input of result.ITEMS) {
+					self.log('debug', `Found input "${input.NAME}" with name "${input.VALUE.NAME}"`);
+					self.INPUTS.push({
+						label: `${input.NAME} (${input.VALUE.NAME})`,
+						id: input.NAME
+					});
+				}
+				self.actions(); // export actions
+			},
+			function(result) {
+				self.log('error', `Could not retrieve input list from TV: ${result.name} - ${result.message}`);
+			});
+	}
+}
 
 // Return config fields for web config
 instance.prototype.config_fields = function () {
@@ -82,6 +108,15 @@ instance.prototype.actions = function (system) {
 				choices: [{ label: 'power on', id: 'power_on' }, { label: 'power off', id: 'power_off' }]
 			}]
 		},
+		'input': {
+			label: 'Active Input',
+			options: [{
+				type: 'dropdown',
+				label: 'Select the input to make active',
+				id: 'input',
+				choices: self.INPUTS
+			}]
+		},
 		'input-manual': {
 			label: 'Active Input - Manual',
 			options: [{
@@ -130,6 +165,7 @@ instance.prototype.action = function (action) {
 
 			break;
 
+		case 'input':
 		case 'input-manual':
 			tv.input.set(opt.input);
 			break;

--- a/index.js
+++ b/index.js
@@ -82,12 +82,12 @@ instance.prototype.actions = function (system) {
 				choices: [{ label: 'power on', id: 'power_on' }, { label: 'power off', id: 'power_off' }]
 			}]
 		},
-		'input': {
-			label: 'Active Input',
+		'input-manual': {
+			label: 'Active Input - Manual',
 			options: [{
 				type: 'textinput',
 				label: 'Enter name of the input to make active',
-				id: 'input'
+				id: 'input-manual'
 			}]
 		}
 	});
@@ -130,7 +130,7 @@ instance.prototype.action = function (action) {
 
 			break;
 
-		case 'input':
+		case 'input-manual':
 			tv.input.set(opt.input);
 			break;
 	}

--- a/index.js
+++ b/index.js
@@ -124,6 +124,28 @@ instance.prototype.actions = function (system) {
 				label: 'Enter name of the input to make active',
 				id: 'input-manual'
 			}]
+		},
+		'mute': {
+			label: 'Set Mute State',
+			options: [{
+				type: 'dropdown',
+				label: 'on/off',
+				id: 'mute',
+				default: 'mute_off',
+				choices: [{ label: 'mute on', id: 'mute_on' }, { label: 'mute off', id: 'mute_off' }]
+			}]
+		},
+		'volume': {
+			label: 'Set Volume Level',
+			options: [{
+				type: 'number',
+				label: 'Volume level (0-100)',
+				id: 'volume',
+				min: 0,
+				max: 100,
+				default: 50,
+				required: true
+			}]
 		}
 	});
 };
@@ -168,6 +190,18 @@ instance.prototype.action = function (action) {
 		case 'input':
 		case 'input-manual':
 			tv.input.set(opt.input);
+			break;
+
+		case 'mute':
+			if (opt.mute === 'mute_off') {
+				tv.control.volume.unmute();
+			} else if (opt.mute === 'mute_on') {
+				tv.control.volume.mute();
+			}
+			break;
+
+		case 'volume':
+			tv.control.volume.set(opt.volume);
 			break;
 	}
 };


### PR DESCRIPTION
This PR adds 4 new actions.

1. Activate Input
    - Provides a dropdown list for the user to select an input to change to.
    - When the module loads, we query the TV for the list of inputs and their names to build the dropdown.
1. Activate Input - Manual
    - Provides a text area for the user to type an input name to change to.
1. Set volume Level
    - Provides a number field to specify any volume level (0-100)
1. Set Mute State
    - Provides a dropdown to select either mute or unmute

I have tested this on several Vizio D50x-G9s. I don't have access to any other model to test on, but I see no reason it shouldn't work with any model supported by the underlying library.