### PR TITLE
Fixed pairing bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,15 @@ instance.prototype.init = function () {
 	var self = this;
 
 	self.status(self.STATUS_UNKNOWN);
-	self.loadInputs();
+
+	if(self.config.host) {
+		self.tv = new smartcast(self.config.host);
+
+		if (self.config.authToken) {
+			self.tv.pairing.useAuthToken(self.config.authToken);
+			self.loadInputs();
+		}
+	}
 };
 
 instance.prototype.updateConfig = function (config) {
@@ -31,23 +39,20 @@ instance.prototype.loadInputs = function () {
 	self.INPUTS = [];
 
 	self.log('debug', 'Enumerating inputs.');
-	if (self.config.host && self.config.authToken) {
-		var tv = new smartcast(self.config.host, self.config.authToken);
-		tv.input.list().then(
-			function(result) {
-				for(input of result.ITEMS) {
-					self.log('debug', `Found input "${input.NAME}" with name "${input.VALUE.NAME}"`);
-					self.INPUTS.push({
-						label: `${input.NAME} (${input.VALUE.NAME})`,
-						id: input.NAME
-					});
-				}
-				self.actions(); // export actions
-			},
-			function(result) {
-				self.log('error', `Could not retrieve input list from TV: ${result.name} - ${result.message}`);
-			});
-	}
+	self.tv.input.list().then(
+		function(result) {
+			for(input of result.ITEMS) {
+				self.log('debug', `Found input "${input.NAME}" with name "${input.VALUE.NAME}"`);
+				self.INPUTS.push({
+					label: `${input.NAME} (${input.VALUE.NAME})`,
+					id: input.NAME
+				});
+			}
+			self.actions(); // export actions
+		},
+		function(result) {
+			self.log('error', `Could not retrieve input list from TV: ${result.name} - ${result.message}`);
+		});
 }
 
 // Return config fields for web config
@@ -80,6 +85,7 @@ instance.prototype.config_fields = function () {
 // When module gets deleted
 instance.prototype.destroy = function () {
 	var self = this;
+	self.tv = null;
 };
 
 instance.prototype.actions = function (system) {
@@ -150,58 +156,50 @@ instance.prototype.actions = function (system) {
 	});
 };
 
-
 instance.prototype.action = function (action) {
 	var self = this;
 	var id = action.action;
 	var opt = action.options;
 
-	var tv = new smartcast(self.config.host);
-
-	if (self.config.authToken !== null) {
-		tv.pairing.useAuthToken(self.config.authToken);
-	}
-
 	switch (id) {
 		case 'pair':
-			tv.pairing.initiate();
+			self.tv.pairing.initiate();
 			break;
 
 		case 'enter_pin':
-			tv.pairing.pair(opt.pin).then(response => {
+			self.tv.pairing.pair(opt.pin).then(response => {
 				self.config.authToken = response.ITEM.AUTH_TOKEN;
 
 				// Ensure the configuration for the device is persisted.
 				self.system.emit('instance_config_put', self.id, self.config, true);
 			});
 
-			tv.pairing.useAuthToken(self.config.authToken);
+			self.tv.pairing.useAuthToken(self.config.authToken);
 			break;
 
 		case 'power':
 			if (opt.power === 'power_off') {
-				tv.control.power.off();
+				self.tv.control.power.off();
 			} else if (opt.power === 'power_on') {
-				tv.control.power.on();
+				self.tv.control.power.on();
 			}
-
 			break;
 
 		case 'input':
 		case 'input-manual':
-			tv.input.set(opt.input);
+			self.tv.input.set(opt.input);
 			break;
 
 		case 'mute':
 			if (opt.mute === 'mute_off') {
-				tv.control.volume.unmute();
+				self.tv.control.volume.unmute();
 			} else if (opt.mute === 'mute_on') {
-				tv.control.volume.mute();
+				self.tv.control.volume.mute();
 			}
 			break;
 
 		case 'volume':
-			tv.control.volume.set(opt.volume);
+			self.tv.control.volume.set(opt.volume);
 			break;
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vizio-smartcast",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"api_version": "1.0.0",
 	"keywords": [
 		"TV"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vizio-smartcast",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"TV"


### PR DESCRIPTION
Fixes : #7 

This PR fixes the pairing function by moving the tv connection up to the instance level, rather than recreating it every time an action ran. The tv object needed to stay consistent between the start pair and finish pair steps because internally it is tracking a request token that has to stay the same or the pairing fails.

I also fixed a typo in the action case statement. The action id is 'pin', but the case statement was looking for 'enter_pin'.

Finally, I added some more logging around the pairing process.