### PR TITLE
Prevent updateConfig from calling loadInputs if there isn't a device paired

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,15 @@ instance.prototype.init = function () {
 instance.prototype.updateConfig = function (config) {
 	var self = this;
 	self.config = config;
-	self.loadInputs();
+
+	if(self.config.host) {
+		self.tv = new smartcast(self.config.host);
+
+		if (self.config.authToken) {
+			self.tv.pairing.useAuthToken(self.config.authToken);
+			self.loadInputs();
+		}
+	}
 };
 
 instance.prototype.loadInputs = function () {

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-	"name": "vizio-smartcast",
-	"version": "1.1.3",
-	"api_version": "1.0.0",
-	"keywords": [
-		"TV"
-	],
-	"manufacturer": "VIZIO",
-	"product": "SmartCast",
-	"shortname": "smartcast",
-	"description": "VIZIO SmartCast plugin for Companion",
-	"main": "index.js",
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
-	"author": "Jeffrey Davidsz <jeffrey.davidsz@vicreo.eu>",
-	"license": "MIT",
-	"dependencies": {
-		"vizio-smart-cast": "^1.3.0"
-	}
+  "name": "vizio-smartcast",
+  "version": "1.1.4",
+  "api_version": "1.0.0",
+  "keywords": [
+    "TV"
+  ],
+  "manufacturer": "VIZIO",
+  "product": "SmartCast",
+  "shortname": "smartcast",
+  "description": "VIZIO SmartCast plugin for Companion",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Jeffrey Davidsz <jeffrey.davidsz@vicreo.eu>",
+  "license": "MIT",
+  "dependencies": {
+    "vizio-smart-cast": "^1.3.0"
+  }
 }


### PR DESCRIPTION
This fixes #11. 

`updateConfig()` was trying to load the list of inputs from the device before it had been paired causing it to throw an exception. This change wraps that call in a conditional so it will only try to load the inputs if the device is paired.