### PR TITLE
Added Support for Tv's with Older Firmware

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -5,7 +5,7 @@
 ## Usage
 
 Create a pair action and launch that action
-When connection is successful it will display a PIN number on the device
+When connection is successful it will display a PIN number on the device (Try switching to the older firmware if pin doesn't display.)
 Create a enter pin action and fill in the pin code, run the action
 
 It should be paired now (you can see it on the device)

--- a/index.js
+++ b/index.js
@@ -19,7 +19,12 @@ instance.prototype.init = function () {
 	self.status(self.STATUS_UNKNOWN);
 
 	if(self.config.host) {
-		self.tv = new smartcast(self.config.host);
+		if (self.config.firmware === 1) {
+			self.tv = new smartcast(self.config.host);
+		} else {
+			self.tv = new smartcast(`${self.config.host}:9000`);
+		}
+		
 
 		if (self.config.authToken) {
 			self.tv.pairing.useAuthToken(self.config.authToken);
@@ -33,7 +38,11 @@ instance.prototype.updateConfig = function (config) {
 	self.config = config;
 
 	if(self.config.host) {
-		self.tv = new smartcast(self.config.host);
+		if (self.config.firmware === 1) {
+			self.tv = new smartcast(self.config.host);
+		} else {
+			self.tv = new smartcast(`${self.config.host}:9000`);
+		}
 
 		if (self.config.authToken) {
 			self.tv.pairing.useAuthToken(self.config.authToken);
@@ -80,6 +89,16 @@ instance.prototype.config_fields = function () {
 			label: 'Target IP',
 			width: 6,
 			regex: self.REGEX_IP
+		},
+		{
+			type: 'dropdown',
+			label: 'Firmware',
+			id: 'firmware',
+			default: '1',
+			choices: [
+			  { id: '1', label: '>4.0' },
+			  { id: '2', label: '<4.0' }
+			]
 		},
 		{
 			type: 'textinput',

--- a/index.js
+++ b/index.js
@@ -19,10 +19,10 @@ instance.prototype.init = function () {
 	self.status(self.STATUS_UNKNOWN);
 
 	if(self.config.host) {
-		if (self.config.firmware === 1) {
-			self.tv = new smartcast(self.config.host);
-		} else {
+		if (self.config.firmware === 2) {
 			self.tv = new smartcast(`${self.config.host}:9000`);
+		} else {
+			self.tv = new smartcast(self.config.host);
 		}
 		
 
@@ -38,10 +38,10 @@ instance.prototype.updateConfig = function (config) {
 	self.config = config;
 
 	if(self.config.host) {
-		if (self.config.firmware === 1) {
-			self.tv = new smartcast(self.config.host);
-		} else {
+		if (self.config.firmware === 2) {
 			self.tv = new smartcast(`${self.config.host}:9000`);
+		} else {
+			self.tv = new smartcast(self.config.host);
 		}
 
 		if (self.config.authToken) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vizio-smartcast",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "api_version": "1.0.0",
   "keywords": [
     "TV"


### PR DESCRIPTION
Added support for Tv's with firmware pre 4.0. This requires a different port number when communicating with the tv. 

`On firmware versions older than 4.0 the API server runs on port 9000, on 4.0 and newer the API server runs on port 7345. Both are using https and will not respond to http.` - [Vizio SmartCast API (2016+ Models)](https://github.com/exiva/Vizio_SmartCast_API)